### PR TITLE
Serve the config library from the template-library.sensible.so bucket

### DIFF
--- a/.github/generator/src/create-template-library.ts
+++ b/.github/generator/src/create-template-library.ts
@@ -10,7 +10,10 @@ import {
 } from "./types";
 
 const REPO_NAME = "sensible-configuration-library";
-const DOWNLOAD_URL_PREFIX = `https://raw.githubusercontent.com/sensible-hq/${REPO_NAME}/main`;
+// Base for every library asset (manifest, configs, ref-doc PDFs, thumbnails).
+// The CI workflow syncs this repo's templates/ tree and the manifest into this
+// Cloudflare-fronted bucket; consumers resolve each asset against this base.
+const DOWNLOAD_URL_PREFIX = "https://template-library.sensible.so";
 
 export async function createTemplateLibrary() {
   const root = path.join(__dirname, "..", "..", "..", "templates");
@@ -24,7 +27,7 @@ export async function createTemplateLibrary() {
   await Promise.all(
     directories.map(async (dirent) => {
       const subgroup = await getLibrarySubGroup(realPath(dirent));
-      if ('children' in subgroup) {
+      if ("children" in subgroup) {
         templateLibrary.library[dirent.name] = subgroup;
       }
     }),
@@ -163,5 +166,5 @@ function getDocPath(dirent: Dirent): string {
 }
 
 function realPath(dirent: Dirent) {
-  return `${dirent.parentPath}/${dirent.name}`
+  return `${dirent.parentPath}/${dirent.name}`;
 }

--- a/.github/generator/src/generate-manifest.ts
+++ b/.github/generator/src/generate-manifest.ts
@@ -1,38 +1,19 @@
 #!/usr/bin/env -S npx ts-node -T
 
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { createHash } from "crypto";
+import { mkdirSync, writeFileSync } from "fs";
+import path from "path";
 import { createTemplateLibrary } from "./create-template-library";
 
-const targets: Record<string, readonly string[]> = {
-  "us-west-2": ["prod", "dev", "exp1"],
-  "eu-west-3": ["prod"],
-  "ca-central-1": ["prod"],
-} as const;
-
-async function uploadLibrary(library: string) {
-  const ContentMD5 = createHash("md5").update(library).digest("base64");
-  await Promise.all(
-    Object.entries(targets).flatMap(async ([region, stages]) => {
-      const s3 = new S3Client({ region });
-      return stages.map(async (stage) =>
-        s3.send(
-          new PutObjectCommand({
-            Bucket: `sensible-so-utility-bucket-${stage}-${region}`,
-            Key: "CONFIG_LIBRARY/manifest_v3.json",
-            Body: library,
-            ContentMD5,
-            ContentType: "application/json",
-          }),
-        ),
-      );
-    }),
-  );
-}
+// Repo-root output/ (gitignored). The CI workflow uploads this manifest and
+// syncs the templates/ tree to the config-library bucket.
+const OUTPUT_DIR = path.join(__dirname, "..", "..", "..", "output");
+const MANIFEST_OUTPUT_PATH = path.join(OUTPUT_DIR, "manifest_v3.json");
 
 async function main() {
   const library = await createTemplateLibrary();
-  await uploadLibrary(library);
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  writeFileSync(MANIFEST_OUTPUT_PATH, library);
+  console.log(`Wrote manifest to ${MANIFEST_OUTPUT_PATH}`);
 }
 
 main().catch((error) => {

--- a/.github/workflows/generate-upload-manifest.yml
+++ b/.github/workflows/generate-upload-manifest.yml
@@ -22,7 +22,19 @@ jobs:
       - name: Install dependencies
         run: cd .github/generator && npm ci
       - name: Generate manifest.json
+        run: cd .github/generator && src/generate-manifest.ts
+      - name: Sync library to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: cd .github/generator && src/generate-manifest.ts
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          # Mirror the templates tree (configs, ref-doc PDFs, thumbnails).
+          # --delete removes objects for templates deleted from the repo.
+          aws s3 sync templates/ s3://template-library.sensible.so/templates/ \
+            --delete \
+            --cache-control "public, max-age=3600"
+          # Upload the manifest last so it never references not-yet-synced files.
+          aws s3 cp output/manifest_v3.json s3://template-library.sensible.so/manifest_v3.json \
+            --cache-control "public, max-age=3600" \
+            --content-type application/json


### PR DESCRIPTION
## Summary
- Point `baseUrl` at the Cloudflare-fronted `template-library.sensible.so` bucket (instead of raw GitHub), so consumers resolve manifest, configs, ref-doc PDFs, and thumbnails from our own CDN.
- The generator now writes the manifest to `output/manifest_v3.json` (gitignored); the workflow `aws s3 sync`s the `templates/` tree and uploads the manifest to the bucket.
- `--delete` on the sync mirrors template removals; `Cache-Control: public, max-age=3600` on both content and manifest. AWS creds moved to the upload step only.

## How it deploys / seeds
- Merging this PR triggers the existing `generate-upload-manifest` workflow (on PR merge), which performs the first full sync — that seeds the bucket.
- It can also be run via `workflow_dispatch` on this branch to seed/verify before merge.

## Notes for reviewer
- Backend + frontend PRs (reading from the CDN) are separate and land alongside this; the infra (the bucket + the `github.config-library` write grant) is already deployed.
- Content cache is 1h rather than `immutable` because template files are edited in place (same filename → same key), so `immutable` would serve stale content after an in-place fix.
- The AWS SDK deps in `.github/generator/package.json` are now unused (upload is done by the AWS CLI in the workflow); left in place to avoid a lockfile churn — can drop in a follow-up.
- Two incidental prettier fixes in `create-template-library.ts` (quote style + a trailing semicolon) came from the formatter touching lines near the edit.
- Validated locally: generator runs, manifest `baseUrl` is the CDN and structure is intact; `jest` and `eslint` pass.